### PR TITLE
Fix issues with local development db

### DIFF
--- a/api/model/db.js
+++ b/api/model/db.js
@@ -16,9 +16,9 @@ export default async function () {
     return Promise.resolve(connection);
   }
   return new Promise(function (res, rej) {
+    connected = true;
     connection.connect(function (err) {
-      if (err) throw rej(err);
-      connected = true;
+      if (err) rej(err);
       res(connection);
     });
   });

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,5 +1,5 @@
 FROM mysql:5.5
 
 ENV MYSQL_DATABASE milehigh_grassroots_law
-ENV MYSQL_ROOT_PASSWORD glpdev
+ENV MYSQL_ROOT_PASSWORD glp411!
 COPY dump.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
# Description

Fixes an issue with the local development database (the password had gotten out of sync with the container info). Also makes it so that the db connection code surfaces the error a little more clearly. You should now be able to access the API locally when running the docker container (i.e. http://localhost:1234/api/shootings).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules