### PR TITLE
Adds labels to BrutalityOverTime charts, accessibility improvements

### DIFF
--- a/components/widgets/BrutalityMap.js
+++ b/components/widgets/BrutalityMap.js
@@ -27,6 +27,7 @@ const MapChart = ({ data }) => {
             const cur = data.find((s) => s.state === geo.properties.name);
             return (
               <Geography
+                aria-label={geo.properties.name}
                 key={geo.rsmKey}
                 geography={geo}
                 fill={cur ? colorScale(cur.total) : "#eee"}

--- a/components/widgets/BrutalityOverTime.js
+++ b/components/widgets/BrutalityOverTime.js
@@ -20,47 +20,45 @@ const BrutalityOverTime = ({ data }) => {
   });
 
   return (
-    <div style={{ marginBottom: "30px" }}>
-      <div style={{ marginBottom: "30px" }}>
-        <VictoryChart
-          width={500}
-          height={470}
-          scale={{ x: "time" }}
-          containerComponent={
-            <VictoryZoomContainer
-              zoomDimension="x"
-              zoomDomain={zoomDomain}
-              onZoomDomainChange={setZoomDomain}
-            />
-          }
-        >
-          <VictoryLine
-            style={{
-              data: { stroke: COLORS.accent },
-            }}
-            data={transformData(data)}
+    <div>
+      <VictoryChart
+        width={500}
+        height={470}
+        scale={{ x: "time" }}
+        containerComponent={
+          <VictoryZoomContainer
+            zoomDimension="x"
+            zoomDomain={zoomDomain}
+            onZoomDomainChange={setZoomDomain}
           />
-          <VictoryAxis
-            label="Span of Time"
-            style={{
-              axisLabel: {
-                fontSize: 10,
-                padding: 30,
-              },
-            }}
-          />
-          <VictoryAxis
-            dependentAxis
-            label="Number of Shootings"
-            style={{
-              axisLabel: {
-                fontSize: 10,
-                padding: 30,
-              },
-            }}
-          />
-        </VictoryChart>
-      </div>
+        }
+      >
+        <VictoryLine
+          style={{
+            data: { stroke: COLORS.accent },
+          }}
+          data={transformData(data)}
+        />
+        <VictoryAxis
+          label="Span of Time"
+          style={{
+            axisLabel: {
+              fontSize: 10,
+              padding: 30,
+            },
+          }}
+        />
+        <VictoryAxis
+          dependentAxis
+          label="Number of Shootings"
+          style={{
+            axisLabel: {
+              fontSize: 10,
+              padding: 30,
+            },
+          }}
+        />
+      </VictoryChart>
       <VictoryChart
         padding={{ top: 0, left: 50, right: 50, bottom: 30 }}
         width={500}

--- a/components/widgets/BrutalityOverTime.js
+++ b/components/widgets/BrutalityOverTime.js
@@ -14,37 +14,57 @@ function transformData(data) {
   });
 }
 
-const BrutalityOverTime = ({data}) => {
-
+const BrutalityOverTime = ({ data }) => {
   const [zoomDomain, setZoomDomain] = useState({
     x: [new Date("2019-09"), new Date("2019-12")],
   });
 
   return (
-    <div>
-      <VictoryChart
-        width={500}
-        height={470}
-        scale={{ x: "time" }}
-        containerComponent={
-          <VictoryZoomContainer
-            zoomDimension="x"
-            zoomDomain={zoomDomain}
-            onZoomDomainChange={setZoomDomain}
+    <div style={{ marginBottom: "30px" }}>
+      <div style={{ marginBottom: "30px" }}>
+        <VictoryChart
+          width={500}
+          height={470}
+          scale={{ x: "time" }}
+          containerComponent={
+            <VictoryZoomContainer
+              zoomDimension="x"
+              zoomDomain={zoomDomain}
+              onZoomDomainChange={setZoomDomain}
+            />
+          }
+        >
+          <VictoryLine
+            style={{
+              data: { stroke: COLORS.accent },
+            }}
+            data={transformData(data)}
           />
-        }
-      >
-        <VictoryLine
-          style={{
-            data: { stroke: COLORS.accent },
-          }}
-          data={transformData(data)}
-        />
-      </VictoryChart>
+          <VictoryAxis
+            label="Span of Time"
+            style={{
+              axisLabel: {
+                fontSize: 10,
+                padding: 30,
+              },
+            }}
+          />
+          <VictoryAxis
+            dependentAxis
+            label="Number of Shootings"
+            style={{
+              axisLabel: {
+                fontSize: 10,
+                padding: 15,
+              },
+            }}
+          />
+        </VictoryChart>
+      </div>
       <VictoryChart
         padding={{ top: 0, left: 50, right: 50, bottom: 30 }}
         width={500}
-        height={100}
+        height={150}
         scale={{ x: "time" }}
         containerComponent={
           <VictoryBrushContainer
@@ -61,9 +81,19 @@ const BrutalityOverTime = ({data}) => {
           }}
           data={transformData(data)}
         />
+        <VictoryAxis
+          dependentAxis
+          label="# of Shootings"
+          style={{
+            axisLabel: {
+              fontSize: 10,
+              padding: 15,
+            },
+          }}
+        />
       </VictoryChart>
     </div>
   );
-}
+};
 
 export default BrutalityOverTime;

--- a/components/widgets/BrutalityOverTime.js
+++ b/components/widgets/BrutalityOverTime.js
@@ -55,7 +55,7 @@ const BrutalityOverTime = ({ data }) => {
             style={{
               axisLabel: {
                 fontSize: 10,
-                padding: 15,
+                padding: 30,
               },
             }}
           />
@@ -87,7 +87,7 @@ const BrutalityOverTime = ({ data }) => {
           style={{
             axisLabel: {
               fontSize: 10,
-              padding: 15,
+              padding: 30,
             },
           }}
         />

--- a/package-lock.json
+++ b/package-lock.json
@@ -2545,6 +2545,11 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
+		"can-use-dom": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
+			"integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
+		},
 		"caniuse-api": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -2833,6 +2838,11 @@
 			"requires": {
 				"toggle-selection": "^1.0.6"
 			}
+		},
+		"core-js": {
+			"version": "3.6.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+			"integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
 		},
 		"core-js-compat": {
 			"version": "3.6.5",
@@ -5485,6 +5495,11 @@
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
 			"integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
 		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5494,6 +5509,11 @@
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"lodash.throttle": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
 		},
 		"lodash.uniq": {
 			"version": "4.5.0",
@@ -7783,6 +7803,28 @@
 					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
 					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
 				}
+			}
+		},
+		"simplebar": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/simplebar/-/simplebar-5.2.1.tgz",
+			"integrity": "sha512-nfOsptB/tb1kzSOaDIJFcrm8EXj5J0pZBPLGetJR8SE6v+97cbedtlNH/L81okgjsFlF11kDndmZ0mscaGAILw==",
+			"requires": {
+				"can-use-dom": "^0.1.0",
+				"core-js": "^3.0.1",
+				"lodash.debounce": "^4.0.8",
+				"lodash.memoize": "^4.1.2",
+				"lodash.throttle": "^4.1.1",
+				"resize-observer-polyfill": "^1.5.1"
+			}
+		},
+		"simplebar-react": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-2.2.1.tgz",
+			"integrity": "sha512-uPGCmcwGNhk7YPguz+K+dUmPZsWpuzqjyYWXfLDoHh4+R/aiJQWaCZH8KvPu/acItn+KVBHcmJKqIwPjggOiig==",
+			"requires": {
+				"prop-types": "^15.6.1",
+				"simplebar": "^5.2.1"
 			}
 		},
 		"slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"react-google-charts": "^3.0.15",
 		"react-simple-maps": "^2.1.2",
 		"react-use": "^15.3.0",
+		"simplebar-react": "^2.2.1",
 		"victory": "^34.3.11"
 	},
 	"devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -11,6 +11,15 @@ function MyApp({ Component, pageProps }) {
           integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
           crossOrigin="anonymous"
         />
+        <style>
+          {/* Adds keyboard navigation focus state for each state image in map */}
+          {`
+            .rsm-geographies path:focus {
+              fill: #274745;
+              outline: none;
+            }
+          `}
+        </style>
       </Head>
       <Component {...pageProps} />
     </>


### PR DESCRIPTION
# Description

Adds:
- ARIA labels per state to increase accessibility of map (otherwise each target has no text)
- missing dependency
- labels to axis of brutality charts
- focus state to state images in map (a dark full color instead of an outline, which had overlap issues)

I've run into two missing dependencies as I've worked, but may be something odd on my end- let me know if the addition of `simplebar-react` as a dependency should be removed and I can peel that commit out.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules