### PR TITLE
Add a by state filter

### DIFF
--- a/api/controllers/appController.js
+++ b/api/controllers/appController.js
@@ -54,7 +54,7 @@ export const count_all_records_by_state_county = function (req, res) {
 };
 
 export const count_all_shootings_by_state_county = function (req, res) {
-  Count.countAllShootingsByStateCounty(function (err, count) {
+  Count.countAllShootingsByStateCounty(req.params.state, function (err, count) {
     if (err) return res.send(err);
     res.send(count);
   });
@@ -89,14 +89,14 @@ export const count_all_brutality_by_stateabbv = function (req, res) {
 };
 
 export const count_all_shootings_over_time = function (req, res) {
-  Count.countAllShootingsOverTime(function (err, count) {
+  Count.countAllShootingsOverTime(req.params.state, function (err, count) {
     if (err) return res.send(err);
     res.send(count);
   });
 };
 
 export const count_top_police_departments = function (req, res) {
-  Count.countTopPoliceDepartments(function (err, count) {
+  Count.countTopPoliceDepartments(req.params.state, function (err, count) {
     if (err) return res.send(err);
     res.send(count);
   });
@@ -118,7 +118,7 @@ export const list_all_shootings_by_state = function (req, res) {
 };
 
 export const list_last_shootings = function (req, res) {
-  Shooting.getLast20Shootings(function (err, shooting) {
+  Shooting.getLast20Shootings(req.params.state, function (err, shooting) {
     if (err) return res.send(err);
     res.send(shooting);
   });

--- a/api/model/appModelCount.js
+++ b/api/model/appModelCount.js
@@ -151,19 +151,18 @@ Count.countAllRecordsByStateCounty = async function (result) {
   );
 };
 
-Count.countAllShootingsByStateCounty = async function (result) {
+Count.countAllShootingsByStateCounty = async function (state, result) {
   const sql = await getDb();
-  sql.query(
-    "Select state, county, count(*) as total from shootings group by state, county order by state, county",
-    function (err, res) {
-      if (err) {
-        console.log("error: ", err);
-        result(err, null);
-      } else {
-        result(null, res);
-      }
+  const where = state ? "where state = ?" : "";
+  let query = `Select state, county, count(*) as total from shootings ${where} group by state, county order by state, county`;
+  sql.query(query, [state], function (err, res) {
+    if (err) {
+      console.log("error: ", err);
+      result(err, null);
+    } else {
+      result(null, res);
     }
-  );
+  });
 };
 
 Count.countAllBrutalityByStateCounty = async function (result) {
@@ -183,34 +182,32 @@ Count.countAllBrutalityByStateCounty = async function (result) {
 
 //BrutalityOverTime.js query
 
-Count.countAllShootingsOverTime = async function (result) {
+Count.countAllShootingsOverTime = async function (state, result) {
   const sql = await getDb();
-  sql.query(
-    "Select count(date) as 'count', date_format(date, '%Y-%m') as 'month' from shootings where date_format(date, '%Y-%m') != '0000-00' group by date_format(date, '%Y-%m') having count(*) >= 1 order by date asc",
-    function (err, res) {
-      if (err) {
-        console.log("error: ", err);
-        result(err, null);
-      } else {
-        result(null, res);
-      }
+  const where = state ? "and state = ?" : "";
+  const query = `Select count(date) as 'count', state, date_format(date, '%Y-%m') as 'month' from shootings where date_format(date, '%Y-%m') != '0000-00' ${where} group by date_format(date, '%Y-%m') having count(*) >= 1 order by date asc`;
+  sql.query(query, [state], function (err, res) {
+    if (err) {
+      console.log("error: ", err);
+      result(err, null);
+    } else {
+      result(null, res);
     }
-  );
+  });
 };
 
-Count.countTopPoliceDepartments = async function (result) {
+Count.countTopPoliceDepartments = async function (state, result) {
   const sql = await getDb();
-  sql.query(
-    "Select police_department, state, count(*) as count from shootings group by police_department order by count desc limit 20",
-    function (err, res) {
-      if (err) {
-        console.log("error: ", err);
-        result(err, null);
-      } else {
-        result(null, res);
-      }
+  const where = state ? "where state = ?" : "";
+  const query = `Select police_department, state, count(*) as count from shootings ${where} group by police_department order by count desc limit 20`;
+  sql.query(query, [state], function (err, res) {
+    if (err) {
+      console.log("error: ", err);
+      result(err, null);
+    } else {
+      result(null, res);
     }
-  );
+  });
 };
 
 export default Count;

--- a/api/model/appModelShootings.js
+++ b/api/model/appModelShootings.js
@@ -41,8 +41,7 @@ Shooting.getShootingByIds = async function (shootingId1, shootingId2, result) {
 
 Shooting.getAllShootings = async function (result) {
   const sql = await getDb();
-  sql.query("Select * from shootings",
-  function (err, res) {
+  sql.query("Select * from shootings", function (err, res) {
     if (err) {
       console.log("error: ", err);
       result(err, null);
@@ -54,22 +53,23 @@ Shooting.getAllShootings = async function (result) {
 
 Shooting.getAllShootingsByState = async function (stateCode, result) {
   const sql = await getDb();
-  sql.query("Select * from shootings where state_code = ?",
-  stateCode,
-  function (err, res) {
-    if (err) {
-      console.log("error: ", err);
-      result(err, null);
-    } else {
-      result(null, res);
+  sql.query(
+    "Select * from shootings where state_code = ?",
+    stateCode,
+    function (err, res) {
+      if (err) {
+        console.log("error: ", err);
+        result(err, null);
+      } else {
+        result(null, res);
+      }
     }
-  });
+  );
 };
 
 Shooting.getAllShootingsByState = async function (result) {
   const sql = await getDb();
-  sql.query("Select * from shootings order by state",
-  function (err, res) {
+  sql.query("Select * from shootings order by state", function (err, res) {
     if (err) {
       console.log("error: ", err);
       result(err, null);
@@ -79,10 +79,11 @@ Shooting.getAllShootingsByState = async function (result) {
   });
 };
 
-Shooting.getLast20Shootings = async function (result) {
+Shooting.getLast20Shootings = async function (state, result) {
   const sql = await getDb();
-  sql.query("Select * from shootings order by date desc limit 20",
-  function (err, res) {
+  const where = state ? "where state = ?" : "";
+  const query = `Select * from shootings ${where} order by date desc limit 20`;
+  sql.query(query, [state], function (err, res) {
     if (err) {
       console.log("error: ", err);
       result(err, null);

--- a/api/routes/appRoutes.js
+++ b/api/routes/appRoutes.js
@@ -32,6 +32,9 @@ const routes = {
   "/count/statecounty": {
     GET: controller.count_all_records_by_state_county,
   },
+  "/count/shootings/statecounty/:state": {
+    GET: controller.count_all_shootings_by_state_county,
+  },
   "/count/shootings/statecounty": {
     GET: controller.count_all_shootings_by_state_county,
   },
@@ -41,7 +44,13 @@ const routes = {
   "/count/shootings/overtime": {
     GET: controller.count_all_shootings_over_time,
   },
+  "/count/shootings/overtime/:state": {
+    GET: controller.count_all_shootings_over_time,
+  },
   "/count/shootings/pd": {
+    GET: controller.count_top_police_departments,
+  },
+  "/count/shootings/pd/:state": {
     GET: controller.count_top_police_departments,
   },
   "/shootings": {
@@ -54,6 +63,9 @@ const routes = {
     GET: controller.list_all_shootings_for_state,
   },
   "/shootings/last20": {
+    GET: controller.list_last_shootings,
+  },
+  "/shootings/last20/:state": {
     GET: controller.list_last_shootings,
   },
   "/shootings/:shootingId1-:shootingId2": {

--- a/components/widgets/BrutalityByState.js
+++ b/components/widgets/BrutalityByState.js
@@ -4,7 +4,7 @@ import { useMeasure } from "react-use";
 
 import { COLORS } from "styles/constants";
 
-const BrutalityByState = ({ data }) => {
+const BrutalityByState = ({ data, x = "state" }) => {
   const [ref, { width }] = useMeasure();
   const sortedData = useMemo(
     () =>
@@ -13,24 +13,25 @@ const BrutalityByState = ({ data }) => {
       }),
     [data]
   );
+  const barWidth = Math.min(50, (1000 - 12 * data.length) / data.length);
   return (
     <div ref={ref} style={{ height: 1000 }}>
       <VictoryChart
-        domainPadding={{ x: 0 }}
-        padding={{ left: 80, top: 50, right: 10, bottom: 50 }}
+        domainPadding={{ x: barWidth / 2 + 5 }}
+        padding={{ left: 100, top: 0, right: 10, bottom: 50 }}
         width={width}
         height={1000}
       >
-        <VictoryAxis style={{ tickLabels: { angle: -40 } }} />
+        <VictoryAxis style={{ tickLabels: { angle: -30 } }} />
         <VictoryAxis dependentAxis />
         <VictoryBar
-          barRatio={0.8}
+          barWidth={barWidth}
           style={{
             data: { fill: COLORS.accent },
           }}
           horizontal
           data={sortedData}
-          x="state"
+          x={x}
           y="total"
         />
       </VictoryChart>

--- a/components/widgets/BrutalityMap.js
+++ b/components/widgets/BrutalityMap.js
@@ -1,10 +1,30 @@
-import React from "react";
-import { ComposableMap, Geographies, Geography } from "react-simple-maps";
+import React, { useState, useMemo } from "react";
+import {
+  ComposableMap,
+  Geographies,
+  Geography,
+  ZoomableGroup,
+  useGeographies,
+} from "react-simple-maps";
 import { scaleQuantile } from "d3-scale";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
+let mapProjection;
+let mapPath;
 
-const MapChart = ({ data }) => {
+const InnerMap = ({ data, selectState, selectedState }) => {
+  const { geographies } = useGeographies({ geography: geoUrl });
+  const selectedGeography = useMemo(
+    () => geographies.find((geo) => geo.properties.name === selectedState),
+    [selectedState, geographies]
+  );
+  const center = useMemo(() => {
+    if (!mapProjection || !mapProjection || !selectedGeography) {
+      return [-96, 36];
+    }
+    return mapProjection.invert(mapPath.centroid(selectedGeography));
+  }, [selectedGeography]);
+  const zoom = selectedGeography ? 3 : 1;
   const colorScale = scaleQuantile()
     .domain(data.map((d) => d.total))
     .range([
@@ -20,22 +40,41 @@ const MapChart = ({ data }) => {
     ]);
 
   return (
-    <ComposableMap projection="geoAlbersUsa">
+    <ZoomableGroup center={center} zoom={zoom} filterZoomEvent={() => {}}>
+      <g className="rsm-geographies">
+        {geographies.map((geo) => {
+          const cur = data.find((s) => s.state === geo.properties.name);
+          return (
+            <Geography
+              aria-label={geo.properties.name}
+              key={geo.rsmKey}
+              geography={geo}
+              fill={cur ? colorScale(cur.total) : "#eee"}
+              onClick={() => selectState(geo.properties.name)}
+            />
+          );
+        })}
+      </g>
       <Geographies geography={geoUrl}>
-        {({ geographies }) =>
-          geographies.map((geo) => {
-            const cur = data.find((s) => s.state === geo.properties.name);
-            return (
-              <Geography
-                aria-label={geo.properties.name}
-                key={geo.rsmKey}
-                geography={geo}
-                fill={cur ? colorScale(cur.total) : "#eee"}
-              />
-            );
-          })
-        }
+        {({ projection, path }) => {
+          mapProjection = projection;
+          mapPath = path;
+        }}
       </Geographies>
+    </ZoomableGroup>
+  );
+};
+
+const MapChart = ({ data, selectState, selectedState }) => {
+  return (
+    <ComposableMap projection="geoAlbersUsa">
+      {
+        <InnerMap
+          data={data}
+          selectState={selectState}
+          selectedState={selectedState}
+        />
+      }
     </ComposableMap>
   );
 };

--- a/components/widgets/BrutalityOverTime.js
+++ b/components/widgets/BrutalityOverTime.js
@@ -1,11 +1,5 @@
-import React, { useState } from "react";
-import {
-  VictoryChart,
-  VictoryZoomContainer,
-  VictoryBrushContainer,
-  VictoryLine,
-  VictoryAxis,
-} from "victory";
+import React from "react";
+import { VictoryChart, VictoryLine, VictoryAxis } from "victory";
 import { useMeasure } from "react-use";
 import { COLORS } from "styles/constants";
 
@@ -16,25 +10,11 @@ function transformData(data) {
 }
 
 const BrutalityOverTime = ({ data }) => {
-  const [zoomDomain, setZoomDomain] = useState({
-    x: [new Date("2020-04"), new Date("2020-06")],
-  });
   const [ref, { width }] = useMeasure();
 
   return (
     <div ref={ref}>
-      <VictoryChart
-        width={width}
-        height={330}
-        scale={{ x: "time" }}
-        containerComponent={
-          <VictoryZoomContainer
-            zoomDimension="x"
-            zoomDomain={zoomDomain}
-            onZoomDomainChange={setZoomDomain}
-          />
-        }
-      >
+      <VictoryChart width={width} height={450} scale={{ x: "time" }}>
         <VictoryLine
           style={{
             data: { stroke: COLORS.accent },
@@ -49,41 +29,11 @@ const BrutalityOverTime = ({ data }) => {
               padding: 30,
             },
           }}
+          domain={[new Date("2020-01"), new Date()]}
         />
         <VictoryAxis
           dependentAxis
           label="Number of Killings"
-          style={{
-            axisLabel: {
-              fontSize: 10,
-              padding: 40,
-            },
-          }}
-        />
-      </VictoryChart>
-      <VictoryChart
-        padding={{ top: 0, left: 50, right: 50, bottom: 0 }}
-        width={width}
-        height={100}
-        scale={{ x: "time" }}
-        containerComponent={
-          <VictoryBrushContainer
-            brushDimension="x"
-            brushDomain={zoomDomain}
-            onBrushDomainChange={setZoomDomain}
-          />
-        }
-      >
-        <VictoryAxis tickFormat={(x) => new Date(x).getFullYear()} />
-        <VictoryLine
-          style={{
-            data: { stroke: COLORS.accent },
-          }}
-          data={transformData(data)}
-        />
-        <VictoryAxis
-          dependentAxis
-          label="# of Killings"
           style={{
             axisLabel: {
               fontSize: 10,

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  webpack: (config, { isServer }) => {
+    // Fixes npm packages that depend on `fs` module
+    if (!isServer) {
+      config.node = {
+        fs: "empty",
+        net: "empty",
+        tls: "empty",
+      };
+    }
+
+    return config;
+  },
+};

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Container, Col, Row, Form } from "react-bootstrap";
+import React, { useState, useEffect } from "react";
+import { Container, Col, Row, Form, Badge } from "react-bootstrap";
 import Head from "pages/head";
 import BrutalityByState from "components/widgets/BrutalityByState";
 import BrutalityOverTime from "components/widgets/BrutalityOverTime";
@@ -7,31 +7,37 @@ import BrutalityMap from "components/widgets/BrutalityMap";
 import EnhancedTable from "components/widgets/TableData";
 import Last20Victims from "components/widgets/Last20Victims";
 import TopPoliceDepartments from "components/widgets/TopPoliceDepartments";
-import { getApiData } from "api/routes/appRoutes";
+import CloseIcon from "@material-ui/icons/Close";
 
 const rowStyle = {
   marginBottom: 20,
 };
 
-export const getServerSideProps = async () => {
-  const shootingsByState = await getApiData("count/shootings/state/name");
+const filterColumnStyle = { display: "flex", alignItems: "center" };
 
+const universalAPIFetch = async (url) => {
+  if (!process.browser) {
+    const { getApiData } = require("api/routes/appRoutes");
+    return getApiData(url);
+  }
+  const rawData = await fetch(`/api/${url}`);
+  return rawData.json();
+};
+
+const getNationalData = async () => {
+  const shootingsByState = await universalAPIFetch(
+    "count/shootings/state/name"
+  );
   const populationDataRaw = await fetch(
     "https://datausa.io/api/data?drilldowns=State&measures=Population&year=latest"
   );
-
-  const shootingsOverTime = await getApiData("count/shootings/overtime");
-
-  const last20Items = await getApiData("shootings/last20");
-
-  const topPoliceDepartments = await getApiData("count/shootings/pd");
-
+  const shootingsOverTime = await universalAPIFetch("count/shootings/overtime");
+  const last20Items = await universalAPIFetch("shootings/last20");
+  const topPoliceDepartments = await universalAPIFetch("count/shootings/pd");
   const populationData = await populationDataRaw.json();
-
   const filteredShootingsByState = shootingsByState.filter((state) =>
     populationData.data.find((s) => s.State === state.state)
   );
-
   const shootingsPerCapita = filteredShootingsByState.map((state) => ({
     ...state,
     total:
@@ -50,6 +56,115 @@ export const getServerSideProps = async () => {
   };
 };
 
+const getStateData = async (state) => {
+  const shootingsByCounty = await universalAPIFetch(
+    `count/shootings/statecounty/${state}`
+  );
+  const shootingsOverTime = await universalAPIFetch(
+    `count/shootings/overtime/${state}`
+  );
+  const last20Items = await universalAPIFetch(`shootings/last20/${state}`);
+  const topPoliceDepartments = await universalAPIFetch(
+    `count/shootings/pd/${state}`
+  );
+
+  return {
+    shootingsByCounty,
+    shootingsOverTime,
+    topPoliceDepartments,
+    last20Items,
+  };
+};
+
+export const getServerSideProps = async () => {
+  const nationalData = await getNationalData();
+  return nationalData;
+};
+
+function Dashboard({
+  shootingsByState,
+  shootingsByGeo,
+  shootingsOverTime,
+  topPoliceDepartments,
+  last20Items,
+  selectedState,
+  setSelectedState,
+  setIsPerCapita,
+}) {
+  return (
+    <Container>
+      <Head />
+      <Row>
+        <Col sm="auto">
+          <h2>Police Killings in 2020</h2>
+        </Col>
+        <Col sm="auto" style={filterColumnStyle}>
+          {selectedState ? (
+            <h4>
+              <Badge pill variant="info" style={{ verticalAlign: "bottom" }}>
+                {selectedState}{" "}
+                <CloseIcon
+                  fontSize="inherit"
+                  onClick={() => setSelectedState(null)}
+                />
+              </Badge>
+            </h4>
+          ) : (
+            <Form.Check
+              type="switch"
+              id="custom-switch"
+              label="Per Capita"
+              onChange={(val) => {
+                setIsPerCapita(val.target.checked);
+              }}
+            />
+          )}
+        </Col>
+      </Row>
+      <Row style={rowStyle}>
+        <Col lg={8}>
+          <h3>Police Killings by State</h3>
+          <Row>
+            <Col></Col>
+          </Row>
+          <BrutalityMap
+            data={shootingsByState}
+            selectState={setSelectedState}
+            selectedState={selectedState}
+          />
+        </Col>
+        <Col lg={4}>
+          <h3>Recent Police Killings</h3>
+          <Last20Victims data={last20Items} />
+        </Col>
+      </Row>
+      <Row style={rowStyle}>
+        <Col lg={8}>
+          <h3>Police Killings by {selectedState ? "County" : "State"}</h3>
+          <BrutalityByState
+            data={shootingsByGeo}
+            x={selectedState ? "county" : "state"}
+          />
+        </Col>
+        <Col lg={4}>
+          <h3>Police Departments with the Most Killings</h3>
+          <TopPoliceDepartments data={topPoliceDepartments} />
+        </Col>
+      </Row>
+      <Row style={rowStyle}>
+        <Col lg={8}>
+          <h3>Police Killings Over Time</h3>
+          <BrutalityOverTime data={shootingsOverTime} />
+        </Col>
+        <Col lg={4}>
+          <h3>By the Numbers</h3>
+          <EnhancedTable />
+        </Col>
+      </Row>
+    </Container>
+  );
+}
+
 function HomePage({
   shootingsByState,
   shootingsPerCapita,
@@ -58,53 +173,41 @@ function HomePage({
   last20Items,
 }) {
   const [isPerCapita, setIsPerCapita] = useState(false);
+  const [selectedState, setSelectedState] = useState(null);
+  const [stateData, setStateData] = useState({
+    shootingsByCounty: [],
+    shootingsOverTime: [],
+    topPoliceDepartments: [],
+    last20Items: [],
+  });
+
+  useEffect(() => {
+    if (selectedState) {
+      getStateData(selectedState).then(setStateData);
+    }
+  }, [selectedState, setStateData]);
+
+  const byState = isPerCapita ? shootingsPerCapita : shootingsByState;
+  const byGeo = selectedState ? stateData.shootingsByCounty : byState;
+  const overTime = selectedState
+    ? stateData.shootingsOverTime
+    : shootingsOverTime;
+  const policeDepartments = selectedState
+    ? stateData.topPoliceDepartments
+    : topPoliceDepartments;
+  const last20 = selectedState ? stateData.last20Items : last20Items;
 
   return (
-    <Container>
-      <Head />
-      <Row style={rowStyle}>
-        <Col lg={8}>
-          <h2>Police Killings by State</h2>
-          <Form.Check
-            type="switch"
-            id="custom-switch"
-            label="Per Capita"
-            onChange={(val) => {
-              setIsPerCapita(val.target.checked);
-            }}
-          />
-          <BrutalityMap
-            data={isPerCapita ? shootingsPerCapita : shootingsByState}
-          />
-        </Col>
-        <Col lg={4}>
-          <h2>Recent Police Killings</h2>
-          <Last20Victims data={last20Items} />
-        </Col>
-      </Row>
-      <Row style={rowStyle}>
-        <Col lg={8}>
-          <h2>Police Killings by State</h2>
-          <BrutalityByState
-            data={isPerCapita ? shootingsPerCapita : shootingsByState}
-          />
-        </Col>
-        <Col lg={4}>
-          <h2>Police Departments with the Most Killings</h2>
-          <TopPoliceDepartments data={topPoliceDepartments} />
-        </Col>
-      </Row>
-      <Row style={rowStyle}>
-        <Col lg={8}>
-          <h2>Highest Number of Killings by Police Department</h2>
-          <BrutalityOverTime data={shootingsOverTime} />
-        </Col>
-        <Col lg={4}>
-          <h2>By the Numbers</h2>
-          <EnhancedTable />
-        </Col>
-      </Row>
-    </Container>
+    <Dashboard
+      shootingsByState={byState}
+      shootingsByGeo={byGeo}
+      shootingsOverTime={overTime}
+      topPoliceDepartments={policeDepartments}
+      last20Items={last20}
+      selectedState={selectedState}
+      setSelectedState={setSelectedState}
+      setIsPerCapita={setIsPerCapita}
+    />
   );
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -96,19 +96,21 @@ function Dashboard({
       <Head />
       <Row>
         <Col sm="auto">
-          <h2>Police Killings in 2020</h2>
+          <h1>Police Killings in 2020</h1>
         </Col>
         <Col sm="auto" style={filterColumnStyle}>
           {selectedState ? (
-            <h4>
-              <Badge pill variant="info" style={{ verticalAlign: "bottom" }}>
-                {selectedState}{" "}
-                <CloseIcon
-                  fontSize="inherit"
-                  onClick={() => setSelectedState(null)}
-                />
-              </Badge>
-            </h4>
+            <Badge
+              pill
+              variant="info"
+              style={{ verticalAlign: "bottom", fontSize: 18 }}
+            >
+              {selectedState}{" "}
+              <CloseIcon
+                fontSize="inherit"
+                onClick={() => setSelectedState(null)}
+              />
+            </Badge>
           ) : (
             <Form.Check
               type="switch"
@@ -123,7 +125,7 @@ function Dashboard({
       </Row>
       <Row style={rowStyle}>
         <Col lg={8}>
-          <h3>Police Killings by State</h3>
+          <h2>Police Killings by State</h2>
           <Row>
             <Col></Col>
           </Row>
@@ -134,30 +136,30 @@ function Dashboard({
           />
         </Col>
         <Col lg={4}>
-          <h3>Recent Police Killings</h3>
+          <h2>Recent Police Killings</h2>
           <Last20Victims data={last20Items} />
         </Col>
       </Row>
       <Row style={rowStyle}>
         <Col lg={8}>
-          <h3>Police Killings by {selectedState ? "County" : "State"}</h3>
+          <h2>Police Killings by {selectedState ? "County" : "State"}</h2>
           <BrutalityByState
             data={shootingsByGeo}
             x={selectedState ? "county" : "state"}
           />
         </Col>
         <Col lg={4}>
-          <h3>Police Departments with the Most Killings</h3>
+          <h2>Police Departments with the Most Killings</h2>
           <TopPoliceDepartments data={topPoliceDepartments} />
         </Col>
       </Row>
       <Row style={rowStyle}>
         <Col lg={8}>
-          <h3>Police Killings Over Time</h3>
+          <h2>Police Killings Over Time</h2>
           <BrutalityOverTime data={shootingsOverTime} />
         </Col>
         <Col lg={4}>
-          <h3>By the Numbers</h3>
+          <h2>By the Numbers</h2>
           <EnhancedTable />
         </Col>
       </Row>


### PR DESCRIPTION
# Description

Adds the ability to zoom in and filter by a single state. Once zoomed in, all of the other widgets filter their data at the state level.

![video](https://media.giphy.com/media/dAnukAl7sNBBpGu3aF/giphy.gif)

- Simplifies the "over time" widget since we are looking at a finite range currently
- Fixes some headers

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules