### PR TITLE
Fixing domain for y axis on timeseries chart

### DIFF
--- a/components/widgets/BrutalityOverTime.js
+++ b/components/widgets/BrutalityOverTime.js
@@ -40,6 +40,8 @@ const BrutalityOverTime = ({ data }) => {
               padding: 40,
             },
           }}
+          domain={[0,250]}
+
         />
       </VictoryChart>
     </div>


### PR DESCRIPTION
# Description

Set a domain for y-axis because it was making June's stat look like it is 0. See screenshot below. Left is before, Right is with the change. I went a hacky route by hardcoding domain, so if there are simpler ways to do it let me know.

![image](https://user-images.githubusercontent.com/17130898/86555077-3fd63a00-bf04-11ea-9fdd-5a893663e8b6.png)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules