### PR TITLE
Updating naming for deadliest police forces

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -188,7 +188,7 @@ function Dashboard({
           </Grid>
           <Grid item xs={12} md={4}>
             <Typography mb={3} variant="h2">
-              Deadliest Police Forces by State
+              Deadliest Police Forces
             </Typography>
             <Box mt={3}>
               <TopPoliceDepartments data={topPoliceDepartments} />


### PR DESCRIPTION

# Description

Currently the title reads as "Deadliest Police Forces by State". Updated to "Deadliest Police Forces" since "by State" won't make sense, when the viz is showing by county in some scenarios

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules