### PR TITLE
Ux tweaks

### DIFF
--- a/components/widgets/BrutalityByState.js
+++ b/components/widgets/BrutalityByState.js
@@ -13,20 +13,20 @@ const BrutalityByState = ({ data, x = "state", isPerCapita }) => {
       }),
     [data]
   );
-  const barWidth = Math.min(50, (1000 - 12 * data.length) / data.length);
+  const barWidth = Math.min(50, (700 - 10 * data.length) / data.length);
   return (
-    <div ref={ref} style={{ height: 1000 }}>
+    <div ref={ref} style={{ height: 700 }}>
       <VictoryChart
         domainPadding={{ x: barWidth / 2 + 5 }}
-        padding={{ left: 100, top: 50, right: 10, bottom: 50 }}
+        padding={{ left: 100, top: 30, right: 10, bottom: 50 }}
         width={width}
-        height={1000}
+        height={700}
       >
         <VictoryAxis dependentAxis orientation={"top"} />
         <VictoryAxis style={{ tickLabels: { angle: -30 } }} />
         <VictoryAxis
           dependentAxis
-          label={isPerCapita ? "Killings Per 1 million Residents" : "Killings"}
+          label={isPerCapita ? "Killings per 1 million residents" : "Killings"}
         />
         <VictoryBar
           barWidth={barWidth}

--- a/components/widgets/BrutalityMap.js
+++ b/components/widgets/BrutalityMap.js
@@ -8,7 +8,6 @@ import {
 } from "react-simple-maps";
 import { scaleQuantile } from "d3-scale";
 import ReactTooltip from "react-tooltip";
-import { VictoryCursorContainer } from "victory";
 
 const geoUrl = "https://cdn.jsdelivr.net/npm/us-atlas@3/states-10m.json";
 let mapProjection;

--- a/components/widgets/BrutalityOverTime.js
+++ b/components/widgets/BrutalityOverTime.js
@@ -14,10 +14,9 @@ function transformData(data) {
 const BrutalityOverTime = ({ data }) => {
   const [ref, { width }] = useMeasure();
   const transformedData = useMemo(() => transformData(data), [data]);
-  const lastDate = new Date(
-    2020,
-    transformedData[transformedData.length - 1].x.getMonth()
-  );
+  const startDate = new Date("2020-01");
+  // Use last month to avoid having an incomplete month of data
+  const endDate = new Date(2020, new Date().getMonth() - 1);
 
   return (
     <div ref={ref}>
@@ -27,7 +26,7 @@ const BrutalityOverTime = ({ data }) => {
             data: { stroke: COLORS.accent },
           }}
           data={transformedData}
-          domain={{ x: [new Date("2020-01"), lastDate] }}
+          domain={{ x: [startDate, endDate] }}
         />
         <VictoryAxis
           label="Span of Time"
@@ -37,7 +36,7 @@ const BrutalityOverTime = ({ data }) => {
               padding: 30,
             },
           }}
-          domain={[new Date("2020-01"), lastDate]}
+          domain={[startDate, endDate]}
         />
         <VictoryAxis
           dependentAxis

--- a/components/widgets/BrutalityOverTime.js
+++ b/components/widgets/BrutalityOverTime.js
@@ -1,16 +1,23 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { VictoryChart, VictoryLine, VictoryAxis } from "victory";
 import { useMeasure } from "react-use";
 import { COLORS } from "styles/constants";
 
 function transformData(data) {
-  return data.map(function (d) {
-    return { x: new Date(d.month), y: d.count };
-  });
+  return data
+    .map(function (d) {
+      return { x: new Date(d.month), y: d.count };
+    })
+    .sort((a, b) => a.x.getTime() - b.x.getTime());
 }
 
 const BrutalityOverTime = ({ data }) => {
   const [ref, { width }] = useMeasure();
+  const transformedData = useMemo(() => transformData(data), [data]);
+  const lastDate = new Date(
+    2020,
+    transformedData[transformedData.length - 1].x.getMonth()
+  );
 
   return (
     <div ref={ref}>
@@ -19,7 +26,8 @@ const BrutalityOverTime = ({ data }) => {
           style={{
             data: { stroke: COLORS.accent },
           }}
-          data={transformData(data)}
+          data={transformedData}
+          domain={{ x: [new Date("2020-01"), lastDate] }}
         />
         <VictoryAxis
           label="Span of Time"
@@ -29,7 +37,7 @@ const BrutalityOverTime = ({ data }) => {
               padding: 30,
             },
           }}
-          domain={[new Date("2020-01"), new Date()]}
+          domain={[new Date("2020-01"), lastDate]}
         />
         <VictoryAxis
           dependentAxis
@@ -40,8 +48,7 @@ const BrutalityOverTime = ({ data }) => {
               padding: 40,
             },
           }}
-          domain={[0,250]}
-
+          domain={[0, 250]}
         />
       </VictoryChart>
     </div>

--- a/components/widgets/BrutalityOverTime.js
+++ b/components/widgets/BrutalityOverTime.js
@@ -4,11 +4,9 @@ import { useMeasure } from "react-use";
 import { COLORS } from "styles/constants";
 
 function transformData(data) {
-  return data
-    .map(function (d) {
-      return { x: new Date(d.month), y: d.count };
-    })
-    .sort((a, b) => a.x.getTime() - b.x.getTime());
+  return data.map(function (d) {
+    return { x: new Date(d.month), y: d.count };
+  });
 }
 
 const BrutalityOverTime = ({ data }) => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,7 +40,7 @@ const getNationalData = async () => {
   const shootingsOverTime = await universalAPIFetch("count/shootings/overtime");
   const last20Items = await universalAPIFetch("shootings/last20");
   const unarmedItems = await universalAPIFetch("count/unarmedKillings");
-  
+
   const topPoliceDepartments = await universalAPIFetch("count/shootings/pd");
   const populationData = await populationDataRaw.json();
   const filteredShootingsByState = shootingsByState.filter((state) =>
@@ -140,7 +140,10 @@ function Dashboard({
         <Grid container spacing={4}>
           <Grid item xs={12}>
             <Box pt={4} pb={2}>
-              <Typography variant="h1">Police Killings in 2020: {unarmedItems[0].total} victims ({unarmedItems[0].weaponStatus} unarmed)</Typography>
+              <Typography variant="h1">
+                Police Killings in 2020: {unarmedItems[0].total} victims (
+                {unarmedItems[0].weaponStatus} unarmed)
+              </Typography>
             </Box>
           </Grid>
 
@@ -156,11 +159,14 @@ function Dashboard({
                 setIsPerCapita={setIsPerCapita}
               />
             </Box>
-            <BrutalityMap
-              data={shootingsByState}
-              selectState={setSelectedState}
-              selectedState={selectedState}
-            />
+            <Box pt={2}>
+              <BrutalityMap
+                data={shootingsByState}
+                selectState={setSelectedState}
+                selectedState={selectedState}
+                isPerCapita={isPerCapita}
+              />
+            </Box>
           </Grid>
           <Grid item xs={12} md={4}>
             <Typography mb={3} variant="h2">
@@ -174,10 +180,11 @@ function Dashboard({
                 setIsPerCapita={setIsPerCapita}
               />
             </Hidden>
-            <Box mt={3} height="500px" overflow="auto">
+            <Box mt={3} height="700px">
               <BrutalityByState
                 data={shootingsByGeo}
                 x={selectedState ? "county" : "state"}
+                isPerCapita={isPerCapita}
               />
             </Box>
           </Grid>


### PR DESCRIPTION
# Description

A number of small UX/clarity improvements:

- Does not display the current month in the "over time" visualization. For now, the heuristic is just looking back to the last month from when the user is viewing the dashboard.
<img width="580" alt="Screen Shot 2020-07-08 at 12 17 13 PM" src="https://user-images.githubusercontent.com/5315170/86961272-cada4e80-c115-11ea-9fda-2a7e2c0eb1df.png">
- Adds better labeling for "per capita" visualizations ("per 1 million residents")
<img width="346" alt="Screen Shot 2020-07-08 at 12 17 06 PM" src="https://user-images.githubusercontent.com/5315170/86961311-e04f7880-c115-11ea-8745-2075697b80ba.png">
<img width="400" alt="Screen Shot 2020-07-08 at 12 16 58 PM" src="https://user-images.githubusercontent.com/5315170/86961315-e0e80f00-c115-11ea-8d84-7dd707cf77db.png">
- Makes it so the state bar chart doesn't need to scroll
<img width="721" alt="Screen Shot 2020-07-08 at 12 16 28 PM" src="https://user-images.githubusercontent.com/5315170/86961360-f3624880-c115-11ea-9526-bc18e398ed68.png">


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules